### PR TITLE
Added check for three occurrences

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -45,6 +45,10 @@ TESTS = {
         {
             "input": ["see you", "e"],
             "answer": 2
+        },
+        {
+            "input": ["three occurrences", "r"],
+            "answer": 10
         }
     ]
 }


### PR DESCRIPTION
The tests at a moment allow wrong solutions, that are counting from the right (rfind):
`if text.count(symbol) < 2: return None`
`return text.rfind(symbol)`
